### PR TITLE
SSH Key Blog Post: prioritize once-formatting instructions

### DIFF
--- a/source/posts/2014-05-10-building-an-encrypted-usb-drive-for-your-ssh-keys-in-os-x.html.markdown.erb
+++ b/source/posts/2014-05-10-building-an-encrypted-usb-drive-for-your-ssh-keys-in-os-x.html.markdown.erb
@@ -7,11 +7,11 @@ description: How to make an encrypted USB key to securely hold your SSH keys in 
 <%= img("Erase", "keychain.jpg") %>
 {: .img_right }
 
-Working on a Platform like [Cloud Foundry](http://pivotal.io/platform), which is relied upon by a growing community of "serious" companies requires us to take security seriously as well.  
+Working on a Platform like [Cloud Foundry](http://pivotal.io/platform), which is relied upon by a growing community of "serious" companies, requires us to take security seriously as well.  
 
 > Security is something you know, something you have, and something you are.
 
-The commonly agreed upon tenants of strong security is that it requires a combination of "something you know, something you have, and something you are."  Two factor authentication includes both of those - usually something you know and something you have.  
+The commonly agreed upon tenets of strong security is that it requires a combination of "something you know, something you have, and something you are."  Two factor authentication includes both of those - usually something you know and something you have.
 
 Here's how we've implemented two factor authentication across the board for our SSH keys using [USB keychain drives](http://www.amazon.com/Kingston-Digital-DataTraveler-DTSE9H-16GBZET/dp/B00DYQYITG).  This strengthens our access to Github repositories and the numerous deployments we manage.
 
@@ -20,7 +20,7 @@ Follow these instructions to increase your security at home and work as well.
 ### Choosing a USB Key
 {: .clear }
 
-We prefer the [Kingston DataTraveler](http://www.amazon.com/Kingston-Digital-DataTraveler-DTSE9H-16GBZET/dp/B00DYQYITG) drive due to its size and cost.  Once you've found a USB keychain drive to your liking, you'll want to reformat it using OS X's built-in encrypted filesystem.
+We prefer the [Kingston DataTraveler](http://www.amazon.com/Kingston-Digital-DataTraveler-DTSE9H-16GBZET/dp/B00DYQYITG) drive due to its size and cost.  Once you've found a USB keychain drive to your liking, you'll want to reformat it using macOS's built-in encrypted filesystem.
 
 ### Format the Drive
 
@@ -28,12 +28,12 @@ We prefer the [Kingston DataTraveler](http://www.amazon.com/Kingston-Digital-Dat
 
 Plug your drive into your computer and open Disk Utility.  Select the disk (not the volume) on the left and navigate to the "Erase" tab.  You'll want to name the volume something simple (such as "keys") to make it easier to access on the command line.
 
-Depending on the format of your USB key's partition table, then the partition table is MBR, which doesn't support encryption, and you won't see encrypted partitions as options in the "Format" dropdown.  In that case, you'll have to do a two-step dance, formatting the drive twice:
+If you see the encrypted options in the dropdown, then just go ahead and format your drive with `Mac OS Extended (Case-sensitive, Journaled, Encrypted)`
+
+However, some USB keys' partition tables are MBR, which doesn't support encryption, and you won't see encrypted partitions as options in the "Format" dropdown.  In that case, you'll have to do a two-step dance, formatting the drive twice:
 
 1. Once as `OS X Extended (Journaled)` using the `GUID Partition Map`, then..
 1. Again, using `Mac OS Extended (Case-sensitive, Journaled, Encrypted)`.
-
-If you see the encrypted options in the dropdown, then just jump straight to #2 above.
 
 Now, you'll be prompted for your decryption password whenever you insert the drive.  Be sure not to save the password into the OS X Keychain.
 
@@ -66,6 +66,8 @@ The key's randomart image is:
 |                 |
 +-----------------+
 ```
+
+Then add the newly-created public key to [your Github account](https://github.com/settings/keys)
 
 ### Script to Load Keys and Eject
 


### PR DESCRIPTION
- It's more common to only need to format your SSH key once, so have that
instruction more prominently
- Other misc. edits

Signed-off-by: C.J. Jameson <cjameson@pivotal.io>