### PR TITLE
Advertise pivotal/usb-login-scripts

### DIFF
--- a/source/posts/2014-05-10-building-an-encrypted-usb-drive-for-your-ssh-keys-in-os-x.html.markdown.erb
+++ b/source/posts/2014-05-10-building-an-encrypted-usb-drive-for-your-ssh-keys-in-os-x.html.markdown.erb
@@ -7,6 +7,8 @@ description: How to make an encrypted USB key to securely hold your SSH keys in 
 <%= img("Erase", "keychain.jpg") %>
 {: .img_right }
 
+UPDATE: This post's process has been encoded and published [in this repo, pivotal/usb-login-scripts](https://github.com/pivotal/usb-login-scripts). Try out the "scripts-autoexpire" for a similar experience with a few extra features.
+
 Working on a Platform like [Cloud Foundry](http://pivotal.io/platform), which is relied upon by a growing community of "serious" companies, requires us to take security seriously as well.  
 
 > Security is something you know, something you have, and something you are.


### PR DESCRIPTION
Because many people as a legacy refer to this blog post, but now the equivalent steps have been automated and encoded into a public repo, we can link to that. Hopefully, if more people use it at that location, it will be well supported and vibrant.